### PR TITLE
feat: add optional heroic rerolls rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ A variant rule that puts dice in the players' hands for every roll:
 - **NPC saves become player overcome checks** -- instead of the GM rolling saves for NPCs, the caster rolls an overcome check against each target's save DC.
 - **Sheet augmentation** -- NPC sheets display DCs, and PC sheets display corresponding modifiers, so the right numbers are always visible.
 
+### Heroic Rerolls
+
+An optional Hero Point variant rule: when a Hero Point rerolls a d20 below 10, the die result becomes 10.
+
 ### Target Helper
 
 Per-target save/check rows on chat cards for spells, area effects, and other targeted actions:
@@ -49,6 +53,7 @@ All settings are world-scoped (GM only) and found under **Module Settings > SF2e
 |---|---|---|
 | **Enable Custom Rules** | Master switch for the entire module. Requires reload. | On |
 | **Enable Target Helper** | Adds per-target rows to chat cards. Requires reload. | On |
+| **Heroic Rerolls** | Raises Hero Point d20 rerolls below 10 to 10. Requires reload. | Off |
 | **Players Roll All Dice** | Enables the PRAD variant. Requires Target Helper to be on. | Off |
 
 ## Development

--- a/scripts/heroic-rerolls/reroll.test.ts
+++ b/scripts/heroic-rerolls/reroll.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { applyHeroicRerollFloor, onHeroicReroll } from "../../src/heroic-rerolls/reroll.js";
+
+function createRoll(result: number, { active = true, faces = 20, number = 1 } = {}) {
+    return {
+        dice: [{ number, faces, results: [{ active, result }] }],
+        _total: result + 7,
+    };
+}
+
+const HERO_POINTS = { slug: "hero-points" };
+
+describe("applyHeroicRerollFloor", () => {
+    it.each([
+        [9, 10],
+        [2, 10],
+        [17, 17],
+    ])("changes a Hero Point reroll of %i to %i", (result, expected) => {
+        const roll = createRoll(result);
+
+        applyHeroicRerollFloor(roll, HERO_POINTS);
+
+        expect(roll.dice[0].results[0].result).toBe(expected);
+        expect(roll._total).toBe(expected + 7);
+    });
+
+    it("leaves a result of 10 unchanged", () => {
+        const roll = createRoll(10);
+
+        expect(applyHeroicRerollFloor(roll, HERO_POINTS)).toBe(false);
+        expect(roll).toEqual(createRoll(10));
+    });
+
+    it("does not change rerolls that do not spend a Hero Point", () => {
+        const roll = createRoll(2);
+
+        expect(applyHeroicRerollFloor(roll, { slug: "mythic-points" })).toBe(false);
+        expect(roll).toEqual(createRoll(2));
+    });
+
+    it("does not change ordinary rerolls without a resource", () => {
+        const roll = createRoll(2);
+
+        expect(applyHeroicRerollFloor(roll, null)).toBe(false);
+        expect(roll).toEqual(createRoll(2));
+    });
+
+    it("does not change an inactive d20 result", () => {
+        const roll = createRoll(2, { active: false });
+
+        expect(applyHeroicRerollFloor(roll, HERO_POINTS)).toBe(false);
+        expect(roll).toEqual(createRoll(2, { active: false }));
+    });
+
+    it("does not change a non-d20 result", () => {
+        const roll = createRoll(2, { faces: 12 });
+
+        expect(applyHeroicRerollFloor(roll, HERO_POINTS)).toBe(false);
+        expect(roll).toEqual(createRoll(2, { faces: 12 }));
+    });
+});
+
+describe("onHeroicReroll", () => {
+    it("floors only the evaluated replacement roll", () => {
+        const oldRoll = createRoll(2);
+        const newRoll = createRoll(9);
+
+        onHeroicReroll(oldRoll as unknown as Roll, newRoll as unknown as Roll, HERO_POINTS);
+
+        expect(oldRoll).toEqual(createRoll(2));
+        expect(newRoll).toEqual(createRoll(10));
+    });
+
+    it("does not throw for ordinary rerolls without a resource", () => {
+        const oldRoll = createRoll(2);
+        const newRoll = createRoll(9);
+
+        onHeroicReroll(oldRoll as unknown as Roll, newRoll as unknown as Roll, null);
+
+        expect(oldRoll).toEqual(createRoll(2));
+        expect(newRoll).toEqual(createRoll(9));
+    });
+});

--- a/src/heroic-rerolls/index.ts
+++ b/src/heroic-rerolls/index.ts
@@ -1,0 +1,4 @@
+/** Heroic Rerolls — Feature Barrel. */
+
+export { registerHeroicRerollsSetting, isHeroicRerollsEnabled } from "./settings.js";
+export { activateHeroicRerolls } from "./reroll.js";

--- a/src/heroic-rerolls/lang/en.json
+++ b/src/heroic-rerolls/lang/en.json
@@ -1,0 +1,10 @@
+{
+    "sf2e-forge-custom": {
+        "settings": {
+            "heroicRerolls": {
+                "name": "Heroic Rerolls",
+                "hint": "When a Hero Point is used to reroll a d20, increase a die result below 10 to 10."
+            }
+        }
+    }
+}

--- a/src/heroic-rerolls/reroll.ts
+++ b/src/heroic-rerolls/reroll.ts
@@ -1,0 +1,55 @@
+/** Heroic Rerolls — Hero Point reroll floor. */
+
+import { MODULE_ID } from "../constants.js";
+
+const HEROIC_REROLL_MINIMUM = 10;
+
+interface HeroicRerollResult {
+    active?: boolean;
+    result: number;
+}
+
+interface HeroicRerollDie {
+    readonly number?: number;
+    readonly faces?: number;
+    readonly results: HeroicRerollResult[];
+}
+
+interface HeroicRerollRoll {
+    readonly dice: readonly HeroicRerollDie[];
+    _total: number;
+}
+
+/**
+ * Apply the Heroic Rerolls floor to an evaluated Hero Point reroll.
+ * Returns whether the roll changed.
+ */
+export function applyHeroicRerollFloor(
+    roll: HeroicRerollRoll,
+    resource: Sf2eRerollResource | null,
+): boolean {
+    if (resource?.slug !== "hero-points") return false;
+
+    const die = roll.dice.find((candidate) => candidate.number === 1 && candidate.faces === 20);
+    const result = die?.results.find((candidate) => candidate.active && candidate.result < HEROIC_REROLL_MINIMUM);
+    if (!result) return false;
+
+    roll._total += HEROIC_REROLL_MINIMUM - result.result;
+    result.result = HEROIC_REROLL_MINIMUM;
+    return true;
+}
+
+/** Handle an evaluated PF2e reroll without mutating the discarded roll. */
+export function onHeroicReroll(
+    _oldRoll: Roll,
+    newRoll: Roll,
+    resource: Sf2eRerollResource | null,
+): void {
+    applyHeroicRerollFloor(newRoll as unknown as HeroicRerollRoll, resource);
+}
+
+/** Activate Heroic Rerolls after Foundry has initialized its hook system. */
+export function activateHeroicRerolls(): void {
+    Hooks.on("pf2e.reroll", onHeroicReroll);
+    console.log(`${MODULE_ID} | Heroic Rerolls variant is ENABLED`);
+}

--- a/src/heroic-rerolls/settings.ts
+++ b/src/heroic-rerolls/settings.ts
@@ -1,0 +1,26 @@
+/**
+ * Heroic Rerolls — Settings
+ *
+ * Registers and exposes the setting that controls the Heroic Rerolls
+ * variant rule.
+ */
+
+import { MODULE_ID } from "../constants.js";
+
+/** Register the Heroic Rerolls setting during the `init` hook. */
+export function registerHeroicRerollsSetting(): void {
+    game.settings!.register(MODULE_ID, "heroicRerolls", {
+        name: "sf2e-forge-custom.settings.heroicRerolls.name",
+        hint: "sf2e-forge-custom.settings.heroicRerolls.hint",
+        scope: "world",
+        config: true,
+        type: Boolean,
+        default: false,
+        requiresReload: true,
+    });
+}
+
+/** Check whether the Heroic Rerolls variant rule is enabled. */
+export function isHeroicRerollsEnabled(): boolean {
+    return game.settings!.get(MODULE_ID, "heroicRerolls");
+}

--- a/src/hooks/init.ts
+++ b/src/hooks/init.ts
@@ -6,12 +6,16 @@
 
 import { MODULE_ID } from "../constants.js";
 import { registerPradSettings, registerPradTemplates, registerAttackCardTemplate } from "../prad/index.js";
+import { registerHeroicRerollsSetting } from "../heroic-rerolls/index.js";
 import { initTargetHelper } from "../target-helper/index.js";
 import { resolveHtmlRoot } from "../shared/html.js";
 
 export function onInit(): void {
     // Register module settings (order matters for the settings UI)
     registerSettings();
+
+    // Register Heroic Rerolls variant setting
+    registerHeroicRerollsSetting();
 
     // Register PRAD (Players Roll All Dice) settings
     registerPradSettings();
@@ -98,6 +102,15 @@ function onRenderSettingsConfig(
         if (thInput && !masterEnabled) {
             thInput.disabled = true;
             thInput.closest(".form-group")?.classList.add("disabled");
+        }
+
+        // Find the Heroic Rerolls setting row and disable it if master is off
+        const heroicRerollsInput = root.querySelector<HTMLInputElement>(
+            `input[name="${MODULE_ID}.heroicRerolls"]`,
+        );
+        if (heroicRerollsInput && !masterEnabled) {
+            heroicRerollsInput.disabled = true;
+            heroicRerollsInput.closest(".form-group")?.classList.add("disabled");
         }
 
         // Disable the strict DC setting when PRAD is off

--- a/src/hooks/ready.ts
+++ b/src/hooks/ready.ts
@@ -4,6 +4,7 @@
  */
 
 import { MODULE_ID } from "../constants.js";
+import { activateHeroicRerolls, isHeroicRerollsEnabled } from "../heroic-rerolls/index.js";
 import { isPradEnabled, applyDCBaseSetting, registerAttackInterceptHook, registerPradSheetHooks } from "../prad/index.js";
 import { activateTargetHelper, setPradOvercomeEnabled } from "../target-helper/index.js";
 
@@ -16,6 +17,11 @@ export function onReady(): void {
     }
 
     console.log(`${MODULE_ID} | Custom rules are active.`);
+
+    // ─── Heroic Rerolls (Hero Point rerolls have a minimum d20 of 10) ───
+    if (isHeroicRerollsEnabled()) {
+        activateHeroicRerolls();
+    }
 
     const targetHelperEnabled = game.settings!.get(MODULE_ID, "enableTargetHelper") as boolean;
     const pradEnabled = isPradEnabled() && targetHelperEnabled;

--- a/src/types/fvtt-augments.d.ts
+++ b/src/types/fvtt-augments.d.ts
@@ -17,6 +17,7 @@ declare global {
     interface SettingConfig {
         "sf2e-forge-custom.enableCustomRules": boolean;
         "sf2e-forge-custom.enableTargetHelper": boolean;
+        "sf2e-forge-custom.heroicRerolls": boolean;
         "sf2e-forge-custom.playersRollAllDice": boolean;
         "sf2e-forge-custom.pradStrictDCs": boolean;
     }
@@ -264,6 +265,16 @@ declare global {
         readonly results?: ReadonlyArray<{ readonly result: number }>;
     }
 
+    /** Resource spent by the PF2e reroll hook. */
+    interface Sf2eRerollResource {
+        readonly slug: string;
+    }
+
+    /** Mutable PF2e reroll options exposed to hook consumers. */
+    interface Sf2eRerollHookOptions {
+        keep?: "new" | "higher" | "lower";
+    }
+
     // ─── Chat Message Flags ──────────────────────────────────────────────
 
     /** Typed shape for accessing `message.flags`. */
@@ -340,5 +351,18 @@ declare global {
     }
 
 } // end declare global
+
+declare module "fvtt-types/configuration" {
+    namespace Hooks {
+        interface HookConfig {
+            "pf2e.reroll": (
+                oldRoll: Roll,
+                newRoll: Roll,
+                resource: Sf2eRerollResource | null,
+                options: Sf2eRerollHookOptions,
+            ) => void;
+        }
+    }
+}
 
 export {};


### PR DESCRIPTION
## Summary

Hero Point rerolls can now use the optional Heroic Rerolls variant: any rerolled d20 result below 10 becomes 10. The rule is disabled by default and can be enabled independently from PRAD in the module settings.

The implementation uses PF2e's evaluated `pf2e.reroll` hook, before PF2e selects the kept roll and calculates degree of success. Ordinary rerolls, Mythic Point rerolls, inactive die results, and non-d20 rolls remain unchanged.

## Test Plan

- `npm test`
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- Enable **Heroic Rerolls**, reload Foundry, spend a Hero Point to reroll a check, and confirm results below 10 display and resolve as 10 while results of 10 or higher remain unchanged.

## Post-Deploy Monitoring & Validation

- During the first play session after deployment, the GM or module maintainer should enable **Heroic Rerolls**, reload Foundry, and exercise Hero Point rerolls below and above 10.
- Search the browser console for `sf2e-forge-custom`, `Heroic Rerolls`, and reroll-related errors.
- Healthy signal: Hero Point rerolls below 10 resolve as 10, higher rolls remain unchanged, and ordinary or Mythic Point rerolls keep their native behavior.
- Failure signal: incorrect totals, incorrect degrees of success, console exceptions during rerolls, or non-Hero-Point rerolls changing. Mitigation: disable **Heroic Rerolls** and reload Foundry.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![OpenAI API](https://img.shields.io/badge/OpenAI_API-000000)
